### PR TITLE
Include the error data.

### DIFF
--- a/actionscript/src/com/freshplanet/ane/AirInAppPurchase/InAppPurchase.as
+++ b/actionscript/src/com/freshplanet/ane/AirInAppPurchase/InAppPurchase.as
@@ -183,7 +183,7 @@ package com.freshplanet.ane.AirInAppPurchase
 					e = new InAppPurchaseEvent(InAppPurchaseEvent.PRODUCT_INFO_RECEIVED, event.level);
 					break;
 				case "PRODUCT_INFO_ERROR":
-					e = new InAppPurchaseEvent(InAppPurchaseEvent.PRODUCT_INFO_ERROR);
+					e = new InAppPurchaseEvent(InAppPurchaseEvent.PRODUCT_INFO_ERROR, event.level);
 					break;
 				default:
 				


### PR DESCRIPTION
At least on iOS, this data is the list of purchase ids that failed, which is very useful, and
there appears to be no other way to get this information.
